### PR TITLE
Adding Dmipy to ohbm hackathon tutorial resources

### DIFF
--- a/Tutorial_Resources.md
+++ b/Tutorial_Resources.md
@@ -52,7 +52,7 @@
   + [Cloud computing](#cloud-computing)
   + [Reproducible neuroimaging tools](#reproducible-neuroimaging-tools)
     - [The Brain Imaging Data Structure (BIDS)](#the-brain-imaging-data-structure-bids)
-    - [Diffusion Microstructure Imaging in Python (Dmipy)](#diffusion-microstructure-imaging-in-python)
+    - [Diffusion Microstructure Imaging in Python (Dmipy)](#diffusion-microstructure-imaging-in-python-dmipy)
   + [Other specific topics](#other-specific-topics)
 * [Statistics](#statistics)
 * [Machine Learning and Deep Learning](#machine-learning-and-deep-learning)

--- a/Tutorial_Resources.md
+++ b/Tutorial_Resources.md
@@ -52,6 +52,7 @@
   + [Cloud computing](#cloud-computing)
   + [Reproducible neuroimaging tools](#reproducible-neuroimaging-tools)
     - [The Brain Imaging Data Structure (BIDS)](#the-brain-imaging-data-structure-bids)
+    - [Diffusion Microstructure Imaging in Python (Dmipy)](#diffusion-microstructure-imaging-in-python)
   + [Other specific topics](#other-specific-topics)
 * [Statistics](#statistics)
 * [Machine Learning and Deep Learning](#machine-learning-and-deep-learning)
@@ -470,6 +471,11 @@ Be sure to check the newly formed [Neuroimaging quality control task force](http
 * the [BIDS website](http://bids.neuroimaging.io/)
 * the [BIDS apps](bids-apps.neuroimaging.io/apps/)
 * the [BIDS starter kit](https://github.com/bids-standard/bids-starter-kit)
+
+#### Diffusion Microstructure Imaging in Python (Dmipy)
+The Dmipy software project is dedicated to fasciliting high-level, reproducible diffusion microstructure research.
+* The [Dmipy open-source repository](https://github.com/AthenaEPI/dmipy) with many microstructure model implementation examples. 
+* Our Preliminary [Reference Paper](https://hal.inria.fr/hal-01873353/file/dmipy-diffusion-microstructure.pdf)
 
 
 ### Other specific topics

--- a/Tutorial_Resources.md
+++ b/Tutorial_Resources.md
@@ -474,7 +474,7 @@ Be sure to check the newly formed [Neuroimaging quality control task force](http
 
 #### Diffusion Microstructure Imaging in Python (Dmipy)
 The Dmipy software project is dedicated to fasciliting high-level, reproducible diffusion microstructure research.
-* The [Dmipy open-source repository](https://github.com/AthenaEPI/dmipy) with many microstructure model implementation examples. 
+* The [Dmipy open-source repository](https://github.com/AthenaEPI/dmipy) with many examples on implementing and fitting microstructure models. 
 * Our Preliminary [Reference Paper](https://hal.inria.fr/hal-01873353/file/dmipy-diffusion-microstructure.pdf)
 
 


### PR DESCRIPTION
Hello,

I would like to add our open-source software project [Diffusion Microstructure Imaging in Python (Dmipy)](https://github.com/AthenaEPI/dmipy) to your tutorial resources.

The purpose of Dmipy is to fascilitate high level and most of all reproducible diffusion microstructure research using diffusion MRI. In essence, it is an extremely versatile and easy to use 'microstructure model generator' that can combine and fit any combination of tissue models using generalized optimization approaches.

I've added some lines of text in your resources that seemed to fit with your style, but I'm sure you'll want to give me some instructions to improve it :) What else should I do?

Thank you for setting up these very nice resources! 